### PR TITLE
lz4: fix test to check if the library was found

### DIFF
--- a/eigersim/clz4.py
+++ b/eigersim/clz4.py
@@ -8,7 +8,7 @@ c_char_p = ctypes.POINTER(ctypes.c_char)
 
 def _load_lib(name='lz4'):
     lz4_name = ctypes.util.find_library(name)
-    if not name:
+    if not lz4_name:
         raise ValueError(f'Cannot find {name}')
     lib = ctypes.CDLL(lz4_name)
     lib.LZ4_compress_default.argtypes = [c_char_p, c_char_p, c_int, c_int]


### PR DESCRIPTION
I just noticed this while my setup didn't include the lz4 library to run the simulator. I think the check should be for the found library, not the input name, right?